### PR TITLE
feat: Implement i18n and update work history

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -13,4 +13,8 @@ export default defineConfig({
       applyBaseStyles: false,
     }),
   ],
+  i18n: {
+    locales: ['es', 'en', 'pt'],
+    defaultLocale: 'en',
+  },
 })

--- a/dev.log
+++ b/dev.log
@@ -1,0 +1,3 @@
+
+> @area44/astro-shadcn-ui-template@23.12.26 dev
+> astro dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "contentful": "^10.8.6",
+        "flag-icons": "^7.5.0",
         "lucide-react": "^0.363.0",
         "moment-timezone": "^0.5.45",
         "motion": "^10.17.0",
@@ -180,6 +181,7 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.6.tgz",
       "integrity": "sha512-qAHSfAdVyFmIvl0VHELib8xar7ONuSHrE2hLnsaWkYNTI68dmi1x8GYDhJjMI/e7XWal9QBlZkwbOnkcw7Z8gQ==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.6",
@@ -2360,6 +2362,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
       "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2373,6 +2376,7 @@
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2382,6 +2386,7 @@
       "version": "18.3.0",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -2556,6 +2561,7 @@
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/astro/-/astro-4.9.1.tgz",
       "integrity": "sha512-9TsoAu0WBPiqyAIj9H0JW7R+tIjPjFsPKo70Nja6WL3imTTuUJQmnCre4ZVmoNV3oicTTlb+N4zjRYANW0Ty9A==",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.8.0",
         "@astrojs/internal-helpers": "0.4.0",
@@ -2823,6 +2829,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001587",
         "electron-to-chromium": "^1.4.668",
@@ -3580,6 +3587,12 @@
         "micromatch": "^4.0.2",
         "pkg-dir": "^4.2.0"
       }
+    },
+    "node_modules/flag-icons": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/flag-icons/-/flag-icons-7.5.0.tgz",
+      "integrity": "sha512-kd+MNXviFIg5hijH766tt+3x76ele1AXlo4zDdCxIvqWZhKt4T83bOtxUOOMlTx/EcFdUMH5yvQgYlFh1EqqFg==",
+      "license": "MIT"
     },
     "node_modules/flattie": {
       "version": "1.1.1",
@@ -5858,6 +5871,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -6001,6 +6015,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
       "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6184,6 +6199,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6195,6 +6211,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7313,6 +7330,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.3.tgz",
       "integrity": "sha512-U7sxQk/n397Bmx4JHbJx/iSOOv5G+II3f1kpLpY2QeUv5DcPdcTsYLlusZfq1NthHS1c1cZoyFmmkex1rzke0A==",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -7473,6 +7491,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "devOptional": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7762,6 +7781,7 @@
       "version": "5.2.11",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.11.tgz",
       "integrity": "sha512-HndV31LWW05i1BLPMUCE1B9E9GFbOu1MbenhS58FuK6owSO5qHm7GiCotrNY1YE5rMeQSFBGmT5ZaLEjFizgiQ==",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.20.1",
         "postcss": "^8.4.38",
@@ -8456,6 +8476,7 @@
       "version": "3.23.8",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
       "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "contentful": "^10.8.6",
+    "flag-icons": "^7.5.0",
     "lucide-react": "^0.363.0",
     "moment-timezone": "^0.5.45",
     "motion": "^10.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ dependencies:
   contentful:
     specifier: ^10.8.6
     version: 10.8.6
+  flag-icons:
+    specifier: ^7.5.0
+    version: 7.5.0
   lucide-react:
     specifier: ^0.363.0
     version: 0.363.0(react@18.2.0)
@@ -2695,6 +2698,10 @@ packages:
     dependencies:
       micromatch: 4.0.5
       pkg-dir: 4.2.0
+    dev: false
+
+  /flag-icons@7.5.0:
+    resolution: {integrity: sha512-kd+MNXviFIg5hijH766tt+3x76ele1AXlo4zDdCxIvqWZhKt4T83bOtxUOOMlTx/EcFdUMH5yvQgYlFh1EqqFg==}
     dev: false
 
   /flattie@1.1.0:

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,12 @@
 ---
-import { buttonVariants } from '../components/ui/button'
-import { ModeToggle } from '../components/ui/ThemeToggle'
+import { getRelativeLocaleUrl } from 'astro:i18n'
+import { useTranslations } from '../i18n'
+import LanguageSwitcher from './LanguageSwitcher.astro'
+import { buttonVariants } from './ui/button'
+import { ModeToggle } from './ui/ThemeToggle'
+
+const { currentLocale } = Astro
+const t = useTranslations(currentLocale as string)
 ---
 
 <script is:inline>
@@ -24,20 +30,25 @@ import { ModeToggle } from '../components/ui/ThemeToggle'
     class="container flex h-16 items-center space-x-4 sm:justify-between sm:space-x-0"
   >
     <div class="flex gap-6 md:gap-10">
-      <a href="/" class="flex items-center space-x-2">
+      <a href={getRelativeLocaleUrl(currentLocale as string, '/')} class="flex items-center space-x-2">
         <span class="inline-block font-bold">Bue221</span>
       </a>
     </div>
     <div class="flex flex-1 items-center justify-end space-x-4">
       <nav class="flex items-center space-x-1">
         <a
-          href="https://github.com/bue221"
-          target="_blank"
-          rel="noreferrer"
+          href={getRelativeLocaleUrl(currentLocale as string, 'work')}
           class={buttonVariants({ variant: 'ghost' })}
         >
-          GitHub
+          {t('nav.work')}
         </a>
+        <a
+          href={getRelativeLocaleUrl(currentLocale as string, 'portfolio')}
+          class={buttonVariants({ variant: 'ghost' })}
+        >
+          {t('nav.projects')}
+        </a>
+        <LanguageSwitcher />
         <ModeToggle transition:persist client:load />
       </nav>
     </div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -30,7 +30,10 @@ const t = useTranslations(currentLocale as string)
     class="container flex h-16 items-center space-x-4 sm:justify-between sm:space-x-0"
   >
     <div class="flex gap-6 md:gap-10">
-      <a href={getRelativeLocaleUrl(currentLocale as string, '/')} class="flex items-center space-x-2">
+      <a
+        href={getRelativeLocaleUrl(currentLocale as string, '/')}
+        class="flex items-center space-x-2"
+      >
         <span class="inline-block font-bold">Bue221</span>
       </a>
     </div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -30,10 +30,7 @@ const t = useTranslations(currentLocale as string)
     class="container flex h-16 items-center space-x-4 sm:justify-between sm:space-x-0"
   >
     <div class="flex gap-6 md:gap-10">
-      <a
-        href={getRelativeLocaleUrl(currentLocale as string, '/')}
-        class="flex items-center space-x-2"
-      >
+      <a href={getRelativeLocaleUrl(currentLocale as string, '/')} class="flex items-center space-x-2">
         <span class="inline-block font-bold">Bue221</span>
       </a>
     </div>

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -1,0 +1,26 @@
+---
+import { getRelativeLocaleUrl } from 'astro:i18n'
+
+const { currentLocale } = Astro
+
+const flags: Record<string, string> = {
+  en: 'us',
+  es: 'es',
+  pt: 'br',
+}
+---
+
+<div class="flex gap-2">
+  {
+    Object.keys(flags).map((locale) => {
+      if (locale === currentLocale) {
+        return <span class:list={['fi', `fi-${flags[locale]}`, 'fis']} />
+      }
+      return (
+        <a href={getRelativeLocaleUrl(locale)}>
+          <span class:list={['fi', `fi-${flags[locale]}`, 'fis']} />
+        </a>
+      )
+    })
+  }
+</div>

--- a/src/components/sections/AboutMe.astro
+++ b/src/components/sections/AboutMe.astro
@@ -1,14 +1,22 @@
 ---
+import { useTranslations } from '../../i18n'
 import Card from '../Card.astro'
+
+const { currentLocale } = Astro
+const t = useTranslations(currentLocale as string)
 ---
 
-<Card colSpan="md:col-span-1" rowSpan="md:row-span-6" title="About me">
+<Card
+  colSpan="md:col-span-1"
+  rowSpan="md:row-span-6"
+  title={t('aboutMe.title')}
+>
   <div class="flex flex-col gap-2">
     <p class="text-sm font-light">
-      Hi, I'm Andrés, a fullstack software developer from Colombia 🇨🇴.
+      {t('aboutMe.p1')}
       <br />
       <br />
-      My primary tools of choice includes:
+      {t('aboutMe.p2')}
       <ul class="list-inside list-disc">
         <li>JavaScript</li>
         <li>React</li>
@@ -21,8 +29,7 @@ import Card from '../Card.astro'
       </ul>
     </p>
     <p class="text-sm font-light">
-      Beyond coding, I'm passionate about tattoo, soccer and traveling. An
-      unusual hobby of mine is play classical music in the guitar or ukulele.
+      {t('aboutMe.p3')}
     </p>
   </div>
 </Card>

--- a/src/components/sections/CVCard.astro
+++ b/src/components/sections/CVCard.astro
@@ -1,12 +1,16 @@
 ---
-import { File } from 'lucide-react'
+import { useTranslations } from '../../i18n'
 import Card from '../Card.astro'
 import { Button } from '../ui/button'
+import { File } from 'lucide-react'
+
+const { currentLocale } = Astro
+const t = useTranslations(currentLocale as string)
 
 const PDF = '/CV English.pdf'
 ---
 
-<Card colSpan="md:col-span-1" rowSpan="md:row-span-4" title="CV">
+<Card colSpan="md:col-span-1" rowSpan="md:row-span-4" title={t('cvCard.title')}>
   <div class="mt-4 flex w-full justify-center">
     <div
       class="card card-compact md:w-112 lg:w-128 w-96 gap-2 border-[oklch(var(--p))] transition-all"
@@ -16,12 +20,12 @@ const PDF = '/CV English.pdf'
       </figure>
       <div class="mt-4 flex flex-col gap-2">
         <p class="text-sm text-muted-foreground">
-          View and download my resume by clicking on the button below
+          {t('cvCard.p')}
         </p>
         <div class="card-actions mt-2 flex w-full items-center justify-center">
           <a target="_blank" href={PDF}>
             <Button>
-              Download resume
+              {t('cvCard.button')}
               <File />
             </Button>
           </a>

--- a/src/components/sections/ContactsCard.astro
+++ b/src/components/sections/ContactsCard.astro
@@ -1,22 +1,26 @@
 ---
+import { useTranslations } from '../../i18n'
 import Card from '../Card.astro'
 import { LINKS } from '../../lib/constants'
+
+const { currentLocale } = Astro
+const t = useTranslations(currentLocale as string)
 ---
 
 <Card colSpan="md:col-span-1" rowSpan="md:row-span-4">
   <div class="h-full">
     <header class="flex items-center">
       <h1 class="text-xl font-bold text-foreground">
-        Let's start working together!
+        {t('contactsCard.title')}
       </h1>
     </header>
     <address class="mt-4 flex flex-col">
-      <h2 class="text-gray-500">Contact Details</h2>
+      <h2 class="text-gray-500">{t('contactsCard.contactDetails')}</h2>
       <p>camiloplaza3@gmail.com</p>
       <p>🇨🇴 Bogotá D.C, Colombia 🇨🇴</p>
     </address>
     <div class="mt-4 flex w-fit flex-col">
-      <h2 class="text-gray-500">Socials</h2>
+      <h2 class="text-gray-500">{t('contactsCard.socials')}</h2>
       <ul>
         <li>
           <a href={LINKS.linkedin} target="_blank">Linkedin</a>

--- a/src/components/sections/IntroCard.astro
+++ b/src/components/sections/IntroCard.astro
@@ -1,22 +1,22 @@
 ---
+import { useTranslations } from '../../i18n'
+import { LINKS } from '../../lib/constants'
 import Card from '../Card.astro'
 import { Button } from '../ui/button'
-import { LINKS } from '../../lib/constants'
-import { Linkedin, Github, Mail } from 'lucide-react'
+import { Github, Linkedin, Mail } from 'lucide-react'
+
+const { currentLocale } = Astro
+const t = useTranslations(currentLocale as string)
 ---
 
 <Card colSpan="md:col-span-3" rowSpan="md:row-span-4">
   <div class="flex h-full w-full">
     <div class="flex flex-col justify-between gap-4 md:max-h-[300px]">
       <div class="flex h-full flex-col">
-        <h6 class="m-0 text-sm font-light text-gray-500">welcome</h6>
-        <p class="m-0 text-xl font-light">
-          Hi, I'm <b class="font-bold">Andrés Camilo Plaza</b>, a software
-          developer, systems engineer and tattoo artist with strong focus on the
-          user experience, animations and micro interactions. I love to create
-          beautiful and functional interfaces, I am passionate about technology
-          and I am always looking for new challenges.
-        </p>
+        <h6 class="m-0 text-sm font-light text-gray-500">
+          {t('introCard.welcome')}
+        </h6>
+        <p class="m-0 text-xl font-light" set:html={t('introCard.p')} />
       </div>
       <div class="flex gap-4">
         <a href={LINKS.github} aria-label="github profile" target="_blank">

--- a/src/components/sections/Now.astro
+++ b/src/components/sections/Now.astro
@@ -1,17 +1,21 @@
 ---
+import { useTranslations } from '../../i18n'
 import Card from '../Card.astro'
 import Pulse from '../Pulse.astro'
+
+const { currentLocale } = Astro
+const t = useTranslations(currentLocale as string)
 ---
 
 <Card colSpan="md:col-span-1" rowSpan="md:row-span-2">
   <div class="mb-2 flex w-full items-start justify-between">
     <div class="flex flex-col">
-      <h2>Now</h2>
+      <h2>{t('now.title')}</h2>
       <a href="https://sive.rs/nowff" target="_blank">
         <span class="cursor-pointer text-xs text-gray-500">what's that ?</span>
       </a>
     </div>
     <Pulse />
   </div>
-  <p class="text-xs">Currently working as freelancer</p>
+  <p class="text-xs">{t('now.p')}</p>
 </Card>

--- a/src/components/sections/StudyCard.astro
+++ b/src/components/sections/StudyCard.astro
@@ -1,10 +1,18 @@
 ---
+import { useTranslations } from '../../i18n'
 import Card from '../Card.astro'
 import { Badge } from '../ui/badge'
 import { STUDIES } from '../../lib/constants'
+
+const { currentLocale } = Astro
+const t = useTranslations(currentLocale as string)
 ---
 
-<Card colSpan="md:col-span-1" rowSpan="md:row-span-1" title="Study">
+<Card
+  colSpan="md:col-span-1"
+  rowSpan="md:row-span-1"
+  title={t('studyCard.title')}
+>
   <div class="mt-2 flex w-full flex-wrap items-center justify-center gap-2">
     {
       STUDIES.map((study) => (

--- a/src/components/sections/TattooCard.astro
+++ b/src/components/sections/TattooCard.astro
@@ -1,12 +1,16 @@
 ---
+import { useTranslations } from '../../i18n'
 import Card from '../Card.astro'
 import { LINKS } from '../../lib/constants'
+
+const { currentLocale } = Astro
+const t = useTranslations(currentLocale as string)
 ---
 
 <Card
   colSpan="md:col-span-1"
   rowSpan="md:row-span-2"
-  title="Instagram tattoo"
+  title={t('tattooCard.title')}
   href={LINKS.instagram}
 >
   <div class="flex h-full w-full flex-col">
@@ -21,7 +25,7 @@ import { LINKS } from '../../lib/constants'
     </div>
     <div>
       <p class="mt-2 text-sm text-muted-foreground">
-        If you want to see my tattoo's, you can follow me on Instagram.
+        {t('tattooCard.p')}
       </p>
     </div>
   </div>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,23 @@
+import en from './locales/en.json'
+import es from './locales/es.json'
+import pt from './locales/pt.json'
+
+const translations: Record<string, Record<string, any>> = {
+  en,
+  es,
+  pt,
+}
+
+export function useTranslations(lang: string) {
+  return function t(key: string): string {
+    const keys = key.split('.')
+    let translation = translations[lang]
+    for (const k of keys) {
+      if (translation === undefined) {
+        break
+      }
+      translation = translation[k]
+    }
+    return translation || key
+  }
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -15,38 +15,6 @@ export const LINKS = {
   discord: 'https://discordapp.com/users/163300027618295808',
 }
 
-// Global
-export const SITE: Site = {
-  TITLE: 'Astro Sphere',
-  DESCRIPTION:
-    'Welcome to Astro Sphere, a portfolio and blog for designers and developers.',
-  AUTHOR: 'Mark Horn',
-}
-
-// Work Page
-export const WORK: Page = {
-  TITLE: 'Work',
-  DESCRIPTION: 'Places I have worked.',
-}
-
-// Blog Page
-export const BLOG: Page = {
-  TITLE: 'Blog',
-  DESCRIPTION: 'Writing on topics I am passionate about.',
-}
-
-// Projects Page
-export const PROJECTS: Page = {
-  TITLE: 'Projects',
-  DESCRIPTION: 'Recent projects I have worked on.',
-}
-
-// Search Page
-export const SEARCH: Page = {
-  TITLE: 'Search',
-  DESCRIPTION: 'Search all posts and projects by keyword.',
-}
-
 // Study Page
 export const STUDIES = [
   {
@@ -83,78 +51,83 @@ export const STUDIES = [
 
 export const EXPERIENCE = [
   {
-    company: 'Straico',
+    company: 'experience.mercadoLibre.company',
+    location: 'Buenos Aires, Argentina',
+    position: 'experience.mercadoLibre.position',
+    start: '2025',
+    link: 'https://mercadolibre.com/',
+    end: 'Current',
+    tasks: [
+      'experience.mercadoLibre.tasks.0',
+      'experience.mercadoLibre.tasks.1',
+      'experience.mercadoLibre.tasks.2',
+    ],
+  },
+  {
+    company: 'experience.straico.company',
     location: 'Bogotá D C, Colombia',
-    position: 'Software Engineer',
+    position: 'experience.straico.position',
     start: '2021',
     link: 'https://straico.com/',
-    end: 'Current',
-    tasks: [
-      'Integration IA services with react and tailwind css',
-      'Development and build of DB with mongoDB',
-    ],
+    end: '2025',
+    tasks: ['experience.straico.tasks.0', 'experience.straico.tasks.1'],
   },
   {
-    company: 'Spot2',
+    company: 'experience.spot2.company',
     location: 'Mexico City, Mexico',
-    position: 'Software Engineer',
+    position: 'experience.spot2.position',
     link: 'https://spot2.mx/',
     start: '2021',
-    end: 'Current',
+    end: '2025',
     tasks: [
-      'Development of the Spot2 platform with the use of React, Redux, and Material UI',
-      'Development map with the use of Google Maps API',
-      'Development internal platform with the use of React, Redux, and Material UI',
-      'Testing and debugging',
+      'experience.spot2.tasks.0',
+      'experience.spot2.tasks.1',
+      'experience.spot2.tasks.2',
+      'experience.spot2.tasks.3',
     ],
   },
   {
-    company: 'Imaginamos',
+    company: 'experience.imaginamos.company',
     link: 'https://imaginamos.com/',
     location: 'Bogotá D C, Colombia',
-    position: 'Frontend developer',
+    position: 'experience.imaginamos.position',
     start: '2021',
     end: '2021',
-    tasks: [
-      'Development of the Imaginamos platform with the use of React, Redux, and Material UI',
-      'Work in ETB project with the use of React, Redux, and Material UI',
-    ],
+    tasks: ['experience.imaginamos.tasks.0', 'experience.imaginamos.tasks.1'],
   },
   {
-    company: 'INETUM',
+    company: 'experience.inetum.company',
     location: 'Bogotá D C, Colombia',
-    position: 'Frontend developer',
+    position: 'experience.inetum.position',
     start: '2021',
     link: 'https://www.inetum.com/es',
     end: '2021',
     tasks: [
-      'Support in the QA area and bug review',
-      'Use of SCRUM methodology',
-      'Claro projects with the use of frameworks and libraries such as react and angular',
-      'Use of redux toolkit as aproposal which allowed a shorter development time when using this tool',
+      'experience.inetum.tasks.0',
+      'experience.inetum.tasks.1',
+      'experience.inetum.tasks.2',
+      'experience.inetum.tasks.3',
     ],
   },
   {
-    company: 'S I G',
+    company: 'experience.sig.company',
     location: 'Bogotá D C, Colombia',
-    position: 'Software developer',
+    position: 'experience.sig.position',
     start: '2021',
     end: '2021',
-    tasks: [
-      'Development of a dashboard with react admin and chartjs for managing and entering information',
-    ],
+    tasks: ['experience.sig.tasks.0'],
   },
   {
-    company: 'BOOKII',
+    company: 'experience.bookii.company',
     location: 'Bogotá D C, Colombia',
-    position: 'Software developer',
+    position: 'experience.bookii.position',
     start: '2019',
     end: '2021',
     tasks: [
-      'Productive collaborationwiththebackendteamforthecreationofthe conversationalclubs',
-      'Effective coding of conversational clubs following design guide lines and using the Redux statemanager',
-      'Creation of the Bookii page in Spanish and change of texts in cms',
-      'Generation of static posts using Gatsby and the Contentful cms for the Bookii blog',
+      'experience.bookii.tasks.0',
+      'experience.bookii.tasks.1',
+      'experience.bookii.tasks.2',
+      'experience.bookii.tasks.3',
     ],
   },
 ]

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,119 @@
+{
+  "site": {
+    "title": "Astro Sphere",
+    "description": "Welcome to Astro Sphere, a portfolio and blog for designers and developers."
+  },
+  "introCard": {
+    "welcome": "welcome",
+    "p": "Hi, I'm <b class=\"font-bold\">Andrés Camilo Plaza</b>, a software developer, systems engineer and tattoo artist with strong focus on the user experience, animations and micro interactions. I love to create beautiful and functional interfaces, I am passionate about technology and I am always looking for new challenges."
+  },
+  "aboutMe": {
+    "title": "About me",
+    "p1": "Hi, I'm Andrés, a fullstack software developer from Colombia 🇨🇴.",
+    "p2": "My primary tools of choice includes:",
+    "p3": "Beyond coding, I'm passionate about tattoo, soccer and traveling. An unusual hobby of mine is play classical music in the guitar or ukulele."
+  },
+  "portfolio": {
+    "title": "Portfolio",
+    "description": "Projects and some clone's that I did",
+    "heading": "Projects and clone's"
+  },
+  "cvCard": {
+    "title": "CV",
+    "p": "View and download my resume by clicking on the button below",
+    "button": "Download resume"
+  },
+  "contactsCard": {
+    "title": "Let's start working together!",
+    "contactDetails": "Contact Details",
+    "socials": "Socials"
+  },
+  "now": {
+    "title": "Now",
+    "p": "Currently working as freelancer"
+  },
+  "studyCard": {
+    "title": "Study"
+  },
+  "tattooCard": {
+    "title": "Instagram tattoo",
+    "p": "If you want to see my tattoo's, you can follow me on Instagram."
+  },
+  "404": {
+    "title": "404 - Not Found",
+    "description": "404 Error — this page was not found",
+    "heading": "Page not found",
+    "p": "Sorry, we couldn't find the page you're looking for.",
+    "button": "Go back home"
+  },
+  "nav": {
+    "home": "Home",
+    "work": "Work",
+    "blog": "Blog",
+    "projects": "Projects"
+  },
+  "experience": {
+    "straico": {
+      "company": "Straico",
+      "position": "Software Engineer",
+      "tasks": [
+        "Integration IA services with react and tailwind css",
+        "Development and build of DB with mongoDB"
+      ]
+    },
+    "spot2": {
+      "company": "Spot2",
+      "position": "Software Engineer",
+      "tasks": [
+        "Development of the Spot2 platform with the use of React, Redux, and Material UI",
+        "Development map with the use of Google Maps API",
+        "Development internal platform with the use of React, Redux, and Material UI",
+        "Testing and debugging"
+      ]
+    },
+    "imaginamos": {
+      "company": "Imaginamos",
+      "position": "Frontend developer",
+      "tasks": [
+        "Development of the Imaginamos platform with the use of React, Redux, and Material UI",
+        "Work in ETB project with the use of React, Redux, and Material UI"
+      ]
+    },
+    "inetum": {
+      "company": "INETUM",
+      "position": "Frontend developer",
+      "tasks": [
+        "Support in the QA area and bug review",
+        "Use of SCRUM methodology",
+        "Claro projects with the use of frameworks and libraries such as react and angular",
+        "Use of redux toolkit as aproposal which allowed a shorter development time when using this tool"
+      ]
+    },
+    "sig": {
+      "company": "S I G",
+      "position": "Software developer",
+      "tasks": [
+        "Development of a dashboard with react admin and chartjs for managing and entering information"
+      ]
+    },
+    "bookii": {
+      "company": "BOOKII",
+      "position": "Software developer",
+      "tasks": [
+        "Productive collaborationwiththebackendteamforthecreationofthe conversationalclubs",
+        "Effective coding of conversational clubs following design guide lines and using the Redux statemanager",
+        "Creation of the Bookii page in Spanish and change of texts in cms",
+        "Generation of static posts using Gatsby and the Contentful cms for the Bookii blog"
+      ]
+    },
+    "mercadoLibre": {
+      "company": "Mercado Libre",
+      "position": "Software Engineer",
+      "tasks": [
+        "Development and maintenance of the Mercado Libre platform",
+        "Collaboration with multidisciplinary teams to create high-quality products",
+        "Implementation of new features and services"
+      ]
+    }
+  }
+}

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1,0 +1,119 @@
+{
+  "site": {
+    "title": "Astro Esfera",
+    "description": "Bienvenido a Astro Esfera, un portafolio y blog para diseñadores y desarrolladores."
+  },
+  "introCard": {
+    "welcome": "bienvenido",
+    "p": "Hola, soy <b class=\"font-bold\">Andrés Camilo Plaza</b>, un desarrollador de software, ingeniero de sistemas y tatuador con un fuerte enfoque en la experiencia de usuario, animaciones y microinteracciones. Me encanta crear interfaces hermosas y funcionales, me apasiona la tecnología y siempre estoy buscando nuevos desafíos."
+  },
+  "aboutMe": {
+    "title": "Sobre mi",
+    "p1": "Hola, soy Andrés, un desarrollador de software fullstack de Colombia 🇨🇴.",
+    "p2": "Mis herramientas principales de elección incluyen:",
+    "p3": "Más allá de la codificación, me apasiona el tatuaje, el fútbol y viajar. Un pasatiempo inusual mío es tocar música clásica en la guitarra o el ukelele."
+  },
+  "portfolio": {
+    "title": "Portafolio",
+    "description": "Proyectos y algunos clones que hice",
+    "heading": "Proyectos y clones"
+  },
+  "cvCard": {
+    "title": "CV",
+    "p": "Mira y descarga mi currículum haciendo clic en el botón de abajo",
+    "button": "Descargar currículum"
+  },
+  "contactsCard": {
+    "title": "¡Empecemos a trabajar juntos!",
+    "contactDetails": "Detalles de contacto",
+    "socials": "Redes sociales"
+  },
+  "now": {
+    "title": "Ahora",
+    "p": "Actualmente trabajando como freelancer"
+  },
+  "studyCard": {
+    "title": "Estudios"
+  },
+  "tattooCard": {
+    "title": "Tatuajes en Instagram",
+    "p": "Si quieres ver mis tatuajes, puedes seguirme en Instagram."
+  },
+  "404": {
+    "title": "404 - No Encontrado",
+    "description": "Error 404 — esta página no fue encontrada",
+    "heading": "Página no encontrada",
+    "p": "Lo sentimos, no pudimos encontrar la página que estás buscando.",
+    "button": "Volver al inicio"
+  },
+  "nav": {
+    "home": "Inicio",
+    "work": "Trabajo",
+    "blog": "Blog",
+    "projects": "Proyectos"
+  },
+  "experience": {
+    "straico": {
+      "company": "Straico",
+      "position": "Ingeniero de Software",
+      "tasks": [
+        "Integración de servicios de IA con React y Tailwind CSS",
+        "Desarrollo y construcción de bases de datos con MongoDB"
+      ]
+    },
+    "spot2": {
+      "company": "Spot2",
+      "position": "Ingeniero de Software",
+      "tasks": [
+        "Desarrollo de la plataforma Spot2 utilizando React, Redux y Material UI",
+        "Desarrollo de mapas utilizando la API de Google Maps",
+        "Desarrollo de plataforma interna utilizando React, Redux y Material UI",
+        "Pruebas y depuración"
+      ]
+    },
+    "imaginamos": {
+      "company": "Imaginamos",
+      "position": "Desarrollador Frontend",
+      "tasks": [
+        "Desarrollo de la plataforma Imaginamos utilizando React, Redux y Material UI",
+        "Trabajo en el proyecto ETB utilizando React, Redux y Material UI"
+      ]
+    },
+    "inetum": {
+      "company": "INETUM",
+      "position": "Desarrollador Frontend",
+      "tasks": [
+        "Soporte en el área de QA y revisión de errores",
+        "Uso de la metodología SCRUM",
+        "Proyectos de Claro utilizando frameworks y librerías como React y Angular",
+        "Uso de Redux Toolkit como propuesta, lo que permitió un menor tiempo de desarrollo al utilizar esta herramienta"
+      ]
+    },
+    "sig": {
+      "company": "S I G",
+      "position": "Desarrollador de Software",
+      "tasks": [
+        "Desarrollo de un dashboard con React Admin y Chart.js para la gestión e ingreso de información"
+      ]
+    },
+    "bookii": {
+      "company": "BOOKII",
+      "position": "Desarrollador de Software",
+      "tasks": [
+        "Colaboración productiva con el equipo de backend para la creación de los clubes de conversación",
+        "Codificación efectiva de los clubes de conversación siguiendo las guías de diseño y utilizando el gestor de estado Redux",
+        "Creación de la página de Bookii en español y cambio de textos en el CMS",
+        "Generación de publicaciones estáticas utilizando Gatsby y el CMS Contentful para el blog de Bookii"
+      ]
+    },
+    "mercadoLibre": {
+      "company": "Mercado Libre",
+      "position": "Ingeniero de Software",
+      "tasks": [
+        "Desarrollo y mantenimiento de la plataforma de Mercado Libre",
+        "Colaboración con equipos multidisciplinarios para crear productos de alta calidad",
+        "Implementación de nuevas funcionalidades y servicios"
+      ]
+    }
+  }
+}

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1,0 +1,119 @@
+{
+  "site": {
+    "title": "Astro Esfera",
+    "description": "Bem-vindo à Astro Esfera, um portfólio e blog para designers e desenvolvedores."
+  },
+  "introCard": {
+    "welcome": "bem-vindo",
+    "p": "Olá, eu sou <b class=\"font-bold\">Andrés Camilo Plaza</b>, um desenvolvedor de software, engenheiro de sistemas e tatuador com forte foco na experiência do usuário, animações e microinterações. Adoro criar interfaces bonitas e funcionais, sou apaixonado por tecnologia e estou sempre em busca de novos desafios."
+  },
+  "aboutMe": {
+    "title": "Sobre mim",
+    "p1": "Olá, eu sou o Andrés, um desenvolvedor de software fullstack da Colômbia 🇨🇴.",
+    "p2": "Minhas principais ferramentas de escolha incluem:",
+    "p3": "Além da codificação, sou apaixonado por tatuagem, futebol e viagens. Um hobby incomum meu é tocar música clássica no violão ou ukulele."
+  },
+  "portfolio": {
+    "title": "Portfólio",
+    "description": "Projetos e alguns clones que eu fiz",
+    "heading": "Projetos e clones"
+  },
+  "cvCard": {
+    "title": "CV",
+    "p": "Veja e baixe meu currículo clicando no botão abaixo",
+    "button": "Baixar currículo"
+  },
+  "contactsCard": {
+    "title": "Vamos começar a trabalhar juntos!",
+    "contactDetails": "Detalhes de contato",
+    "socials": "Redes sociais"
+  },
+  "now": {
+    "title": "Agora",
+    "p": "Atualmente trabalhando como freelancer"
+  },
+  "studyCard": {
+    "title": "Estudo"
+  },
+  "tattooCard": {
+    "title": "Tatuagens no Instagram",
+    "p": "Se você quiser ver minhas tatuagens, pode me seguir no Instagram."
+  },
+  "404": {
+    "title": "404 - Não Encontrado",
+    "description": "Erro 404 — esta página não foi encontrada",
+    "heading": "Página não encontrada",
+    "p": "Desculpe, não conseguimos encontrar a página que você está procurando.",
+    "button": "Voltar ao início"
+  },
+  "nav": {
+    "home": "Início",
+    "work": "Trabalho",
+    "blog": "Blog",
+    "projects": "Projetos"
+  },
+  "experience": {
+    "straico": {
+      "company": "Straico",
+      "position": "Engenheiro de Software",
+      "tasks": [
+        "Integração de serviços de IA com React e Tailwind CSS",
+        "Desenvolvimento e construção de bancos de dados com MongoDB"
+      ]
+    },
+    "spot2": {
+      "company": "Spot2",
+      "position": "Engenheiro de Software",
+      "tasks": [
+        "Desenvolvimento da plataforma Spot2 usando React, Redux e Material UI",
+        "Desenvolvimento de mapas usando a API do Google Maps",
+        "Desenvolvimento de plataforma interna usando React, Redux e Material UI",
+        "Testes e depuração"
+      ]
+    },
+    "imaginamos": {
+      "company": "Imaginamos",
+      "position": "Desenvolvedor Frontend",
+      "tasks": [
+        "Desenvolvimento da plataforma Imaginamos usando React, Redux e Material UI",
+        "Trabalho no projeto ETB usando React, Redux e Material UI"
+      ]
+    },
+    "inetum": {
+      "company": "INETUM",
+      "position": "Desenvolvedor Frontend",
+      "tasks": [
+        "Suporte na área de QA e revisão de bugs",
+        "Uso da metodologia SCRUM",
+        "Projetos da Claro usando frameworks e bibliotecas como React e Angular",
+        "Uso do Redux Toolkit como proposta, o que permitiu um tempo de desenvolvimento menor ao usar esta ferramenta"
+      ]
+    },
+    "sig": {
+      "company": "S I G",
+      "position": "Desenvolvedor de Software",
+      "tasks": [
+        "Desenvolvimento de um dashboard com React Admin e Chart.js para gerenciamento e entrada de informações"
+      ]
+    },
+    "bookii": {
+      "company": "BOOKII",
+      "position": "Desenvolvedor de Software",
+      "tasks": [
+        "Colaboração produtiva com a equipe de backend para a criação dos clubes de conversação",
+        "Codificação eficaz dos clubes de conversação seguindo as diretrizes de design e usando o gerenciador de estado Redux",
+        "Criação da página da Bookii em espanhol e alteração de textos no CMS",
+        "Geração de posts estáticos usando Gatsby e o CMS Contentful para o blog da Bookii"
+      ]
+    },
+    "mercadoLibre": {
+      "company": "Mercado Livre",
+      "position": "Engenheiro de Software",
+      "tasks": [
+        "Desenvolvimento e manutenção da plataforma Mercado Livre",
+        "Colaboração com equipes multidisciplinares para criar produtos de alta qualidade",
+        "Implementação de novas funcionalidades e serviços"
+      ]
+    }
+  }
+}

--- a/src/pages/en/404.astro
+++ b/src/pages/en/404.astro
@@ -1,24 +1,27 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro'
+import { useTranslations } from '../../i18n'
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import { buttonVariants } from '../../components/ui/button'
 
-import { buttonVariants } from '../components/ui/button'
+const { currentLocale } = Astro
+const t = useTranslations(currentLocale as string)
 ---
 
 <BaseLayout
-  title="404 - Not Found"
-  description="404 Error — this page was not found"
+  title={t('404.title')}
+  description={t('404.description')}
 >
   <main class="flex h-[80vh] flex-auto">
     <div class="flex flex-col items-center justify-center px-8">
       <img src="/me_hello.png" alt="404" class="mb-8 size-64" />
       <p class="text-sm text-muted-foreground">404</p>
       <h1 class="text-4xl font-extrabold tracking-tight lg:text-5xl">
-        Page not found
+        {t('404.heading')}
       </h1>
       <p class="mb-4 leading-7 [&:not(:first-child)]:mt-6">
-        Sorry, we couldn't find the page you're looking for.
+        {t('404.p')}
       </p>
-      <a href="/" rel="noreferrer" class={buttonVariants()}> Go back home</a>
+      <a href="/" rel="noreferrer" class={buttonVariants()}> {t('404.button')}</a>
     </div>
   </main>
 </BaseLayout>

--- a/src/pages/en/404.astro
+++ b/src/pages/en/404.astro
@@ -7,10 +7,7 @@ const { currentLocale } = Astro
 const t = useTranslations(currentLocale as string)
 ---
 
-<BaseLayout
-  title={t('404.title')}
-  description={t('404.description')}
->
+<BaseLayout title={t('404.title')} description={t('404.description')}>
   <main class="flex h-[80vh] flex-auto">
     <div class="flex flex-col items-center justify-center px-8">
       <img src="/me_hello.png" alt="404" class="mb-8 size-64" />
@@ -21,7 +18,9 @@ const t = useTranslations(currentLocale as string)
       <p class="mb-4 leading-7 [&:not(:first-child)]:mt-6">
         {t('404.p')}
       </p>
-      <a href="/" rel="noreferrer" class={buttonVariants()}> {t('404.button')}</a>
+      <a href="/" rel="noreferrer" class={buttonVariants()}>
+        {t('404.button')}</a
+      >
     </div>
   </main>
 </BaseLayout>

--- a/src/pages/en/404.astro
+++ b/src/pages/en/404.astro
@@ -7,7 +7,10 @@ const { currentLocale } = Astro
 const t = useTranslations(currentLocale as string)
 ---
 
-<BaseLayout title={t('404.title')} description={t('404.description')}>
+<BaseLayout
+  title={t('404.title')}
+  description={t('404.description')}
+>
   <main class="flex h-[80vh] flex-auto">
     <div class="flex flex-col items-center justify-center px-8">
       <img src="/me_hello.png" alt="404" class="mb-8 size-64" />
@@ -18,9 +21,7 @@ const t = useTranslations(currentLocale as string)
       <p class="mb-4 leading-7 [&:not(:first-child)]:mt-6">
         {t('404.p')}
       </p>
-      <a href="/" rel="noreferrer" class={buttonVariants()}>
-        {t('404.button')}</a
-      >
+      <a href="/" rel="noreferrer" class={buttonVariants()}> {t('404.button')}</a>
     </div>
   </main>
 </BaseLayout>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1,0 +1,89 @@
+---
+import { useTranslations } from '../../i18n'
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import IntroCard from '../../components/sections/IntroCard.astro'
+import AboutMe from '../../components/sections/AboutMe.astro'
+import Card from '../../components/Card.astro'
+import TimeZoneCard from '../../components/sections/TimeZoneCard.astro'
+import ContactsCard from '../../components/sections/ContactsCard.astro'
+import Now from '../../components/sections/Now.astro'
+import CVCard from '../../components/sections/CVCard.astro'
+import ExperienceCard from '../../components/sections/ExperienceCard.astro'
+import TattooCard from '../../components/sections/TattooCard.astro'
+import StudyCard from '../../components/sections/StudyCard.astro'
+//
+import { motion, AnimatePresence } from 'framer-motion'
+
+const { currentLocale } = Astro
+const t = useTranslations(currentLocale as string)
+---
+
+<script>
+  import { stagger, spring, timeline, type TimelineDefinition } from 'motion'
+  import { loaderAnimation } from '../../lib/constants'
+
+  const cards = document.querySelectorAll('.card-animate')
+
+  const sequence = [
+    loaderAnimation,
+    [
+      cards,
+      { y: ['40%', '0%'], opacity: [0, 1] },
+      {
+        at: '-0.1',
+        duration: 0.4,
+        delay: stagger(0.3),
+        easing: spring({ velocity: 100, stiffness: 50, damping: 10 }),
+      },
+    ],
+  ]
+
+  timeline(sequence as TimelineDefinition)
+</script>
+
+<BaseLayout
+  title={t('site.title')}
+  description={t('site.description')}
+>
+  <div
+    slot="loader"
+    class="loader bg-darkslate-700 fixed bottom-0 left-0 right-0 top-0 z-50 flex h-screen w-screen items-center justify-center text-3xl font-black uppercase text-neutral-50"
+  >
+  </div>
+  <main
+    class="relative m-auto grid w-full max-w-6xl gap-2 overflow-hidden p-2 sm:gap-2 sm:p-4 md:grid-cols-2 md:gap-3 md:p-6 lg:grid-cols-4 lg:grid-rows-8 lg:gap-4"
+  >
+    <IntroCard />
+    <AboutMe />
+    <CVCard />
+    <Now />
+    <Card
+      colSpan="md:col-span-1"
+      rowSpan="md:row-span-2"
+      title={t('nav.projects')}
+      href="/portfolio"
+    />
+    <TimeZoneCard />
+    <ContactsCard />
+    <ExperienceCard />
+    <Card colSpan="md:col-span-1" rowSpan="md:row-span-1">
+      <div class="flex h-full flex-col justify-between">
+        <blockquote class="mt-6 border-l-2 pl-6 italic">
+          “Anything one man can imagine, other men can make real.”
+        </blockquote>
+        <p class="mt-2 text-xs">- Jules Verne</p>
+      </div>
+    </Card>
+    <TattooCard />
+    <StudyCard />
+    <!-- <Card colSpan="md:col-span-1" rowSpan="md:row-span-1">
+      <p class="text-xs">
+        © 2023 · Crafted with ♥️ using <a
+          href="https://astro.build/"
+          target="_blank"
+          class="text-red-500">Astro</a
+        > by Gianmarco.
+      </p>
+    </Card> -->
+  </main>
+</BaseLayout>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -41,10 +41,7 @@ const t = useTranslations(currentLocale as string)
   timeline(sequence as TimelineDefinition)
 </script>
 
-<BaseLayout
-  title={t('site.title')}
-  description={t('site.description')}
->
+<BaseLayout title={t('site.title')} description={t('site.description')}>
   <div
     slot="loader"
     class="loader bg-darkslate-700 fixed bottom-0 left-0 right-0 top-0 z-50 flex h-screen w-screen items-center justify-center text-3xl font-black uppercase text-neutral-50"

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -41,7 +41,10 @@ const t = useTranslations(currentLocale as string)
   timeline(sequence as TimelineDefinition)
 </script>
 
-<BaseLayout title={t('site.title')} description={t('site.description')}>
+<BaseLayout
+  title={t('site.title')}
+  description={t('site.description')}
+>
   <div
     slot="loader"
     class="loader bg-darkslate-700 fixed bottom-0 left-0 right-0 top-0 z-50 flex h-screen w-screen items-center justify-center text-3xl font-black uppercase text-neutral-50"

--- a/src/pages/en/portfolio.astro
+++ b/src/pages/en/portfolio.astro
@@ -1,13 +1,16 @@
 ---
-import { WORK } from '../lib/constants'
-import BaseLayout from '../layouts/BaseLayout.astro'
-import TopLayout from '../layouts/TopLayout.astro'
-import BottomLayout from '../layouts/BottomLayout.astro'
-import ProjectCard from '../components/ProjectCard.astro'
+import { useTranslations } from '../../i18n'
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import TopLayout from '../../layouts/TopLayout.astro'
+import BottomLayout from '../../layouts/BottomLayout.astro'
+import ProjectCard from '../../components/ProjectCard.astro'
 
-import { contentfulClient } from '../lib/contentful'
+import { contentfulClient } from '../../lib/contentful'
 import { documentToHtmlString } from '@contentful/rich-text-html-renderer'
 import type { EntryFieldTypes } from 'contentful'
+
+const { currentLocale } = Astro
+const t = useTranslations(currentLocale as string)
 
 interface Project {
   contentTypeId: 'Projects'
@@ -23,15 +26,15 @@ const entries = await contentfulClient.getEntries<Project>({})
 ---
 
 <BaseLayout
-  title="Portfolio"
-  description="Projects and some clone's that I did"
+  title={t('portfolio.title')}
+  description={t('portfolio.description')}
 >
   <main class="flex min-h-[80vh] flex-auto flex-col" transition:animate="slide">
     <TopLayout>
       <h2
         class="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0"
       >
-        Projects and clone's
+        {t('portfolio.heading')}
       </h2>
     </TopLayout>
     <BottomLayout size="xl">

--- a/src/pages/en/work.astro
+++ b/src/pages/en/work.astro
@@ -1,19 +1,21 @@
 ---
-import { WORK } from '../lib/constants'
-import BaseLayout from '../layouts/BaseLayout.astro'
-import TopLayout from '../layouts/TopLayout.astro'
-import BottomLayout from '../layouts/BottomLayout.astro'
+import { useTranslations } from '../../i18n'
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import TopLayout from '../../layouts/TopLayout.astro'
+import BottomLayout from '../../layouts/BottomLayout.astro'
+import { EXPERIENCE } from '../../lib/constants'
 
-import { EXPERIENCE } from '../lib/constants'
+const { currentLocale } = Astro
+const t = useTranslations(currentLocale as string)
 ---
 
-<BaseLayout title={WORK.TITLE} description={WORK.DESCRIPTION}>
+<BaseLayout title={t('nav.work')} description={t('nav.work')}>
   <main class="flex min-h-[80vh] flex-auto flex-col" transition:animate="fade">
     <TopLayout>
       <h2
         class="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0"
       >
-        {WORK.TITLE}
+        {t('nav.work')}
       </h2>
     </TopLayout>
     <BottomLayout>
@@ -28,12 +30,12 @@ import { EXPERIENCE } from '../lib/constants'
                 href={entry.link ?? ''}
                 class={`font-semibold ${entry?.link ? 'text-primary' : 'text-foreground'}`}
               >
-                {entry.company}
+                {t(entry.company)}
               </a>
-              <div class="text-sm font-semibold">{entry.position}</div>
+              <div class="text-sm font-semibold">{t(entry.position)}</div>
               <article class="prose dark:prose-invert">
                 {entry.tasks.map((i) => (
-                  <>{i}</>
+                  <p>{t(i)}</p>
                 ))}
               </article>
             </li>

--- a/src/pages/es/404.astro
+++ b/src/pages/es/404.astro
@@ -7,10 +7,7 @@ const { currentLocale } = Astro
 const t = useTranslations(currentLocale as string)
 ---
 
-<BaseLayout
-  title={t('404.title')}
-  description={t('404.description')}
->
+<BaseLayout title={t('404.title')} description={t('404.description')}>
   <main class="flex h-[80vh] flex-auto">
     <div class="flex flex-col items-center justify-center px-8">
       <img src="/me_hello.png" alt="404" class="mb-8 size-64" />
@@ -21,7 +18,9 @@ const t = useTranslations(currentLocale as string)
       <p class="mb-4 leading-7 [&:not(:first-child)]:mt-6">
         {t('404.p')}
       </p>
-      <a href="/" rel="noreferrer" class={buttonVariants()}> {t('404.button')}</a>
+      <a href="/" rel="noreferrer" class={buttonVariants()}>
+        {t('404.button')}</a
+      >
     </div>
   </main>
 </BaseLayout>

--- a/src/pages/es/404.astro
+++ b/src/pages/es/404.astro
@@ -1,0 +1,27 @@
+---
+import { useTranslations } from '../../i18n'
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import { buttonVariants } from '../../components/ui/button'
+
+const { currentLocale } = Astro
+const t = useTranslations(currentLocale as string)
+---
+
+<BaseLayout
+  title={t('404.title')}
+  description={t('404.description')}
+>
+  <main class="flex h-[80vh] flex-auto">
+    <div class="flex flex-col items-center justify-center px-8">
+      <img src="/me_hello.png" alt="404" class="mb-8 size-64" />
+      <p class="text-sm text-muted-foreground">404</p>
+      <h1 class="text-4xl font-extrabold tracking-tight lg:text-5xl">
+        {t('404.heading')}
+      </h1>
+      <p class="mb-4 leading-7 [&:not(:first-child)]:mt-6">
+        {t('404.p')}
+      </p>
+      <a href="/" rel="noreferrer" class={buttonVariants()}> {t('404.button')}</a>
+    </div>
+  </main>
+</BaseLayout>

--- a/src/pages/es/404.astro
+++ b/src/pages/es/404.astro
@@ -7,7 +7,10 @@ const { currentLocale } = Astro
 const t = useTranslations(currentLocale as string)
 ---
 
-<BaseLayout title={t('404.title')} description={t('404.description')}>
+<BaseLayout
+  title={t('404.title')}
+  description={t('404.description')}
+>
   <main class="flex h-[80vh] flex-auto">
     <div class="flex flex-col items-center justify-center px-8">
       <img src="/me_hello.png" alt="404" class="mb-8 size-64" />
@@ -18,9 +21,7 @@ const t = useTranslations(currentLocale as string)
       <p class="mb-4 leading-7 [&:not(:first-child)]:mt-6">
         {t('404.p')}
       </p>
-      <a href="/" rel="noreferrer" class={buttonVariants()}>
-        {t('404.button')}</a
-      >
+      <a href="/" rel="noreferrer" class={buttonVariants()}> {t('404.button')}</a>
     </div>
   </main>
 </BaseLayout>

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -1,0 +1,89 @@
+---
+import { useTranslations } from '../../i18n'
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import IntroCard from '../../components/sections/IntroCard.astro'
+import AboutMe from '../../components/sections/AboutMe.astro'
+import Card from '../../components/Card.astro'
+import TimeZoneCard from '../../components/sections/TimeZoneCard.astro'
+import ContactsCard from '../../components/sections/ContactsCard.astro'
+import Now from '../../components/sections/Now.astro'
+import CVCard from '../../components/sections/CVCard.astro'
+import ExperienceCard from '../../components/sections/ExperienceCard.astro'
+import TattooCard from '../../components/sections/TattooCard.astro'
+import StudyCard from '../../components/sections/StudyCard.astro'
+//
+import { motion, AnimatePresence } from 'framer-motion'
+
+const { currentLocale } = Astro
+const t = useTranslations(currentLocale as string)
+---
+
+<script>
+  import { stagger, spring, timeline, type TimelineDefinition } from 'motion'
+  import { loaderAnimation } from '../../lib/constants'
+
+  const cards = document.querySelectorAll('.card-animate')
+
+  const sequence = [
+    loaderAnimation,
+    [
+      cards,
+      { y: ['40%', '0%'], opacity: [0, 1] },
+      {
+        at: '-0.1',
+        duration: 0.4,
+        delay: stagger(0.3),
+        easing: spring({ velocity: 100, stiffness: 50, damping: 10 }),
+      },
+    ],
+  ]
+
+  timeline(sequence as TimelineDefinition)
+</script>
+
+<BaseLayout
+  title={t('site.title')}
+  description={t('site.description')}
+>
+  <div
+    slot="loader"
+    class="loader bg-darkslate-700 fixed bottom-0 left-0 right-0 top-0 z-50 flex h-screen w-screen items-center justify-center text-3xl font-black uppercase text-neutral-50"
+  >
+  </div>
+  <main
+    class="relative m-auto grid w-full max-w-6xl gap-2 overflow-hidden p-2 sm:gap-2 sm:p-4 md:grid-cols-2 md:gap-3 md:p-6 lg:grid-cols-4 lg:grid-rows-8 lg:gap-4"
+  >
+    <IntroCard />
+    <AboutMe />
+    <CVCard />
+    <Now />
+    <Card
+      colSpan="md:col-span-1"
+      rowSpan="md:row-span-2"
+      title={t('nav.projects')}
+      href="/portfolio"
+    />
+    <TimeZoneCard />
+    <ContactsCard />
+    <ExperienceCard />
+    <Card colSpan="md:col-span-1" rowSpan="md:row-span-1">
+      <div class="flex h-full flex-col justify-between">
+        <blockquote class="mt-6 border-l-2 pl-6 italic">
+          “Anything one man can imagine, other men can make real.”
+        </blockquote>
+        <p class="mt-2 text-xs">- Jules Verne</p>
+      </div>
+    </Card>
+    <TattooCard />
+    <StudyCard />
+    <!-- <Card colSpan="md:col-span-1" rowSpan="md:row-span-1">
+      <p class="text-xs">
+        © 2023 · Crafted with ♥️ using <a
+          href="https://astro.build/"
+          target="_blank"
+          class="text-red-500">Astro</a
+        > by Gianmarco.
+      </p>
+    </Card> -->
+  </main>
+</BaseLayout>

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -41,10 +41,7 @@ const t = useTranslations(currentLocale as string)
   timeline(sequence as TimelineDefinition)
 </script>
 
-<BaseLayout
-  title={t('site.title')}
-  description={t('site.description')}
->
+<BaseLayout title={t('site.title')} description={t('site.description')}>
   <div
     slot="loader"
     class="loader bg-darkslate-700 fixed bottom-0 left-0 right-0 top-0 z-50 flex h-screen w-screen items-center justify-center text-3xl font-black uppercase text-neutral-50"

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -41,7 +41,10 @@ const t = useTranslations(currentLocale as string)
   timeline(sequence as TimelineDefinition)
 </script>
 
-<BaseLayout title={t('site.title')} description={t('site.description')}>
+<BaseLayout
+  title={t('site.title')}
+  description={t('site.description')}
+>
   <div
     slot="loader"
     class="loader bg-darkslate-700 fixed bottom-0 left-0 right-0 top-0 z-50 flex h-screen w-screen items-center justify-center text-3xl font-black uppercase text-neutral-50"

--- a/src/pages/es/portfolio.astro
+++ b/src/pages/es/portfolio.astro
@@ -48,7 +48,7 @@ const entries = await contentfulClient.getEntries<Project>({})
               subheading={entry?.fields?.description}
               imagePath={entry?.fields?.img?.fields?.file.url}
               altText={entry?.fields?.img?.fields.title}
-              class="w-full sm:w-2/f"
+              class="sm:w-2/f w-full"
             />
           ))
         }

--- a/src/pages/es/portfolio.astro
+++ b/src/pages/es/portfolio.astro
@@ -48,7 +48,7 @@ const entries = await contentfulClient.getEntries<Project>({})
               subheading={entry?.fields?.description}
               imagePath={entry?.fields?.img?.fields?.file.url}
               altText={entry?.fields?.img?.fields.title}
-              class="sm:w-2/f w-full"
+              class="w-full sm:w-2/f"
             />
           ))
         }

--- a/src/pages/es/portfolio.astro
+++ b/src/pages/es/portfolio.astro
@@ -1,0 +1,58 @@
+---
+import { useTranslations } from '../../i18n'
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import TopLayout from '../../layouts/TopLayout.astro'
+import BottomLayout from '../../layouts/BottomLayout.astro'
+import ProjectCard from '../../components/ProjectCard.astro'
+
+import { contentfulClient } from '../../lib/contentful'
+import { documentToHtmlString } from '@contentful/rich-text-html-renderer'
+import type { EntryFieldTypes } from 'contentful'
+
+const { currentLocale } = Astro
+const t = useTranslations(currentLocale as string)
+
+interface Project {
+  contentTypeId: 'Projects'
+  fields: {
+    name: EntryFieldTypes.Text
+    img: EntryFieldTypes.AssetLink
+    website: EntryFieldTypes.EntryResourceLink<any>
+    repositorio: EntryFieldTypes.EntryResourceLink<any>
+  }
+}
+
+const entries = await contentfulClient.getEntries<Project>({})
+---
+
+<BaseLayout
+  title={t('portfolio.title')}
+  description={t('portfolio.description')}
+>
+  <main class="flex min-h-[80vh] flex-auto flex-col" transition:animate="slide">
+    <TopLayout>
+      <h2
+        class="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0"
+      >
+        {t('portfolio.heading')}
+      </h2>
+    </TopLayout>
+    <BottomLayout size="xl">
+      <div class="flex w-full flex-wrap justify-center gap-2">
+        {
+          entries.items.map((entry: any) => (
+            <ProjectCard
+              key={entry?.sys?.id}
+              href={entry?.fields?.website}
+              heading={entry?.fields?.name}
+              subheading={entry?.fields?.description}
+              imagePath={entry?.fields?.img?.fields?.file.url}
+              altText={entry?.fields?.img?.fields.title}
+              class="w-full sm:w-2/f"
+            />
+          ))
+        }
+      </div>
+    </BottomLayout>
+  </main>
+</BaseLayout>

--- a/src/pages/es/work.astro
+++ b/src/pages/es/work.astro
@@ -1,0 +1,47 @@
+---
+import { useTranslations } from '../../i18n'
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import TopLayout from '../../layouts/TopLayout.astro'
+import BottomLayout from '../../layouts/BottomLayout.astro'
+import { EXPERIENCE } from '../../lib/constants'
+
+const { currentLocale } = Astro
+const t = useTranslations(currentLocale as string)
+---
+
+<BaseLayout title={t('nav.work')} description={t('nav.work')}>
+  <main class="flex min-h-[80vh] flex-auto flex-col" transition:animate="fade">
+    <TopLayout>
+      <h2
+        class="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0"
+      >
+        {t('nav.work')}
+      </h2>
+    </TopLayout>
+    <BottomLayout>
+      <ul>
+        {
+          EXPERIENCE.map((entry) => (
+            <li class="animate mt-4 border-b border-black/10 py-8 first-of-type:mt-0 first-of-type:pt-0 last-of-type:border-none dark:border-white/25">
+              <div class="mb-4 text-sm uppercase">
+                {entry.start} - {entry.end}
+              </div>
+              <a
+                href={entry.link ?? ''}
+                class={`font-semibold ${entry?.link ? 'text-primary' : 'text-foreground'}`}
+              >
+                {t(entry.company)}
+              </a>
+              <div class="text-sm font-semibold">{t(entry.position)}</div>
+              <article class="prose dark:prose-invert">
+                {entry.tasks.map((i) => (
+                  <p>{t(i)}</p>
+                ))}
+              </article>
+            </li>
+          ))
+        }
+      </ul>
+    </BottomLayout>
+  </main>
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,11 +4,13 @@ import { getRelativeLocaleUrl } from 'astro:i18n'
 const { currentLocale } = Astro
 ---
 
-<script define:vars={{
-  defaultLocale: 'en',
-  targetUrl: getRelativeLocaleUrl('en')
-}}>
-  window.location.href = targetUrl;
+<script
+  define:vars={{
+    defaultLocale: 'en',
+    targetUrl: getRelativeLocaleUrl('en'),
+  }}
+>
+  window.location.href = targetUrl
 </script>
 
 <div class="h-screen w-screen bg-black"></div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,13 +4,11 @@ import { getRelativeLocaleUrl } from 'astro:i18n'
 const { currentLocale } = Astro
 ---
 
-<script
-  define:vars={{
-    defaultLocale: 'en',
-    targetUrl: getRelativeLocaleUrl('en'),
-  }}
->
-  window.location.href = targetUrl
+<script define:vars={{
+  defaultLocale: 'en',
+  targetUrl: getRelativeLocaleUrl('en')
+}}>
+  window.location.href = targetUrl;
 </script>
 
 <div class="h-screen w-screen bg-black"></div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,85 +1,14 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro'
-import IntroCard from '../components/sections/IntroCard.astro'
-import AboutMe from '../components/sections/AboutMe.astro'
-import Card from '../components/Card.astro'
-import TimeZoneCard from '../components/sections/TimeZoneCard.astro'
-import ContactsCard from '../components/sections/ContactsCard.astro'
-import Now from '../components/sections/Now.astro'
-import CVCard from '../components/sections/CVCard.astro'
-import ExperienceCard from '../components/sections/ExperienceCard.astro'
-import TattooCard from '../components/sections/TattooCard.astro'
-import StudyCard from '../components/sections/StudyCard.astro'
-//
-import { motion, AnimatePresence } from 'framer-motion'
+import { getRelativeLocaleUrl } from 'astro:i18n'
+
+const { currentLocale } = Astro
 ---
 
-<script>
-  import { stagger, spring, timeline, type TimelineDefinition } from 'motion'
-  import { loaderAnimation } from '../lib/constants'
-
-  const cards = document.querySelectorAll('.card-animate')
-
-  const sequence = [
-    loaderAnimation,
-    [
-      cards,
-      { y: ['40%', '0%'], opacity: [0, 1] },
-      {
-        at: '-0.1',
-        duration: 0.4,
-        delay: stagger(0.3),
-        easing: spring({ velocity: 100, stiffness: 50, damping: 10 }),
-      },
-    ],
-  ]
-
-  timeline(sequence as TimelineDefinition)
+<script define:vars={{
+  defaultLocale: 'en',
+  targetUrl: getRelativeLocaleUrl('en')
+}}>
+  window.location.href = targetUrl;
 </script>
 
-<BaseLayout
-  title="Andrés Plaza - Full Stack Developer"
-  description="Andrés Plaza - Full Stack Developer - Portfolio, Projects, CV, About Me, Contact, Timezone, Now, Experience, Tattoo, Study"
->
-  <div
-    slot="loader"
-    class="loader bg-darkslate-700 fixed bottom-0 left-0 right-0 top-0 z-50 flex h-screen w-screen items-center justify-center text-3xl font-black uppercase text-neutral-50"
-  >
-  </div>
-  <main
-    class="relative m-auto grid w-full max-w-6xl gap-2 overflow-hidden p-2 sm:gap-2 sm:p-4 md:grid-cols-2 md:gap-3 md:p-6 lg:grid-cols-4 lg:grid-rows-8 lg:gap-4"
-  >
-    <IntroCard />
-    <AboutMe />
-    <CVCard />
-    <Now />
-    <Card
-      colSpan="md:col-span-1"
-      rowSpan="md:row-span-2"
-      title="Portfolio & Projects"
-      href="/portfolio"
-    />
-    <TimeZoneCard />
-    <ContactsCard />
-    <ExperienceCard />
-    <Card colSpan="md:col-span-1" rowSpan="md:row-span-1">
-      <div class="flex h-full flex-col justify-between">
-        <blockquote class="mt-6 border-l-2 pl-6 italic">
-          “Anything one man can imagine, other men can make real.”
-        </blockquote>
-        <p class="mt-2 text-xs">- Jules Verne</p>
-      </div>
-    </Card>
-    <TattooCard />
-    <StudyCard />
-    <!-- <Card colSpan="md:col-span-1" rowSpan="md:row-span-1">
-      <p class="text-xs">
-        © 2023 · Crafted with ♥️ using <a
-          href="https://astro.build/"
-          target="_blank"
-          class="text-red-500">Astro</a
-        > by Gianmarco.
-      </p>
-    </Card> -->
-  </main>
-</BaseLayout>
+<div class="h-screen w-screen bg-black"></div>

--- a/src/pages/pt/404.astro
+++ b/src/pages/pt/404.astro
@@ -7,10 +7,7 @@ const { currentLocale } = Astro
 const t = useTranslations(currentLocale as string)
 ---
 
-<BaseLayout
-  title={t('404.title')}
-  description={t('404.description')}
->
+<BaseLayout title={t('404.title')} description={t('404.description')}>
   <main class="flex h-[80vh] flex-auto">
     <div class="flex flex-col items-center justify-center px-8">
       <img src="/me_hello.png" alt="404" class="mb-8 size-64" />
@@ -21,7 +18,9 @@ const t = useTranslations(currentLocale as string)
       <p class="mb-4 leading-7 [&:not(:first-child)]:mt-6">
         {t('404.p')}
       </p>
-      <a href="/" rel="noreferrer" class={buttonVariants()}> {t('404.button')}</a>
+      <a href="/" rel="noreferrer" class={buttonVariants()}>
+        {t('404.button')}</a
+      >
     </div>
   </main>
 </BaseLayout>

--- a/src/pages/pt/404.astro
+++ b/src/pages/pt/404.astro
@@ -1,0 +1,27 @@
+---
+import { useTranslations } from '../../i18n'
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import { buttonVariants } from '../../components/ui/button'
+
+const { currentLocale } = Astro
+const t = useTranslations(currentLocale as string)
+---
+
+<BaseLayout
+  title={t('404.title')}
+  description={t('404.description')}
+>
+  <main class="flex h-[80vh] flex-auto">
+    <div class="flex flex-col items-center justify-center px-8">
+      <img src="/me_hello.png" alt="404" class="mb-8 size-64" />
+      <p class="text-sm text-muted-foreground">404</p>
+      <h1 class="text-4xl font-extrabold tracking-tight lg:text-5xl">
+        {t('404.heading')}
+      </h1>
+      <p class="mb-4 leading-7 [&:not(:first-child)]:mt-6">
+        {t('404.p')}
+      </p>
+      <a href="/" rel="noreferrer" class={buttonVariants()}> {t('404.button')}</a>
+    </div>
+  </main>
+</BaseLayout>

--- a/src/pages/pt/404.astro
+++ b/src/pages/pt/404.astro
@@ -7,7 +7,10 @@ const { currentLocale } = Astro
 const t = useTranslations(currentLocale as string)
 ---
 
-<BaseLayout title={t('404.title')} description={t('404.description')}>
+<BaseLayout
+  title={t('404.title')}
+  description={t('404.description')}
+>
   <main class="flex h-[80vh] flex-auto">
     <div class="flex flex-col items-center justify-center px-8">
       <img src="/me_hello.png" alt="404" class="mb-8 size-64" />
@@ -18,9 +21,7 @@ const t = useTranslations(currentLocale as string)
       <p class="mb-4 leading-7 [&:not(:first-child)]:mt-6">
         {t('404.p')}
       </p>
-      <a href="/" rel="noreferrer" class={buttonVariants()}>
-        {t('404.button')}</a
-      >
+      <a href="/" rel="noreferrer" class={buttonVariants()}> {t('404.button')}</a>
     </div>
   </main>
 </BaseLayout>

--- a/src/pages/pt/index.astro
+++ b/src/pages/pt/index.astro
@@ -1,0 +1,89 @@
+---
+import { useTranslations } from '../../i18n'
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import IntroCard from '../../components/sections/IntroCard.astro'
+import AboutMe from '../../components/sections/AboutMe.astro'
+import Card from '../../components/Card.astro'
+import TimeZoneCard from '../../components/sections/TimeZoneCard.astro'
+import ContactsCard from '../../components/sections/ContactsCard.astro'
+import Now from '../../components/sections/Now.astro'
+import CVCard from '../../components/sections/CVCard.astro'
+import ExperienceCard from '../../components/sections/ExperienceCard.astro'
+import TattooCard from '../../components/sections/TattooCard.astro'
+import StudyCard from '../../components/sections/StudyCard.astro'
+//
+import { motion, AnimatePresence } from 'framer-motion'
+
+const { currentLocale } = Astro
+const t = useTranslations(currentLocale as string)
+---
+
+<script>
+  import { stagger, spring, timeline, type TimelineDefinition } from 'motion'
+  import { loaderAnimation } from '../../lib/constants'
+
+  const cards = document.querySelectorAll('.card-animate')
+
+  const sequence = [
+    loaderAnimation,
+    [
+      cards,
+      { y: ['40%', '0%'], opacity: [0, 1] },
+      {
+        at: '-0.1',
+        duration: 0.4,
+        delay: stagger(0.3),
+        easing: spring({ velocity: 100, stiffness: 50, damping: 10 }),
+      },
+    ],
+  ]
+
+  timeline(sequence as TimelineDefinition)
+</script>
+
+<BaseLayout
+  title={t('site.title')}
+  description={t('site.description')}
+>
+  <div
+    slot="loader"
+    class="loader bg-darkslate-700 fixed bottom-0 left-0 right-0 top-0 z-50 flex h-screen w-screen items-center justify-center text-3xl font-black uppercase text-neutral-50"
+  >
+  </div>
+  <main
+    class="relative m-auto grid w-full max-w-6xl gap-2 overflow-hidden p-2 sm:gap-2 sm:p-4 md:grid-cols-2 md:gap-3 md:p-6 lg:grid-cols-4 lg:grid-rows-8 lg:gap-4"
+  >
+    <IntroCard />
+    <AboutMe />
+    <CVCard />
+    <Now />
+    <Card
+      colSpan="md:col-span-1"
+      rowSpan="md:row-span-2"
+      title={t('nav.projects')}
+      href="/portfolio"
+    />
+    <TimeZoneCard />
+    <ContactsCard />
+    <ExperienceCard />
+    <Card colSpan="md:col-span-1" rowSpan="md:row-span-1">
+      <div class="flex h-full flex-col justify-between">
+        <blockquote class="mt-6 border-l-2 pl-6 italic">
+          “Anything one man can imagine, other men can make real.”
+        </blockquote>
+        <p class="mt-2 text-xs">- Jules Verne</p>
+      </div>
+    </Card>
+    <TattooCard />
+    <StudyCard />
+    <!-- <Card colSpan="md:col-span-1" rowSpan="md:row-span-1">
+      <p class="text-xs">
+        © 2023 · Crafted with ♥️ using <a
+          href="https://astro.build/"
+          target="_blank"
+          class="text-red-500">Astro</a
+        > by Gianmarco.
+      </p>
+    </Card> -->
+  </main>
+</BaseLayout>

--- a/src/pages/pt/index.astro
+++ b/src/pages/pt/index.astro
@@ -41,10 +41,7 @@ const t = useTranslations(currentLocale as string)
   timeline(sequence as TimelineDefinition)
 </script>
 
-<BaseLayout
-  title={t('site.title')}
-  description={t('site.description')}
->
+<BaseLayout title={t('site.title')} description={t('site.description')}>
   <div
     slot="loader"
     class="loader bg-darkslate-700 fixed bottom-0 left-0 right-0 top-0 z-50 flex h-screen w-screen items-center justify-center text-3xl font-black uppercase text-neutral-50"

--- a/src/pages/pt/index.astro
+++ b/src/pages/pt/index.astro
@@ -41,7 +41,10 @@ const t = useTranslations(currentLocale as string)
   timeline(sequence as TimelineDefinition)
 </script>
 
-<BaseLayout title={t('site.title')} description={t('site.description')}>
+<BaseLayout
+  title={t('site.title')}
+  description={t('site.description')}
+>
   <div
     slot="loader"
     class="loader bg-darkslate-700 fixed bottom-0 left-0 right-0 top-0 z-50 flex h-screen w-screen items-center justify-center text-3xl font-black uppercase text-neutral-50"

--- a/src/pages/pt/portfolio.astro
+++ b/src/pages/pt/portfolio.astro
@@ -48,7 +48,7 @@ const entries = await contentfulClient.getEntries<Project>({})
               subheading={entry?.fields?.description}
               imagePath={entry?.fields?.img?.fields?.file.url}
               altText={entry?.fields?.img?.fields.title}
-              class="w-full sm:w-2/f"
+              class="sm:w-2/f w-full"
             />
           ))
         }

--- a/src/pages/pt/portfolio.astro
+++ b/src/pages/pt/portfolio.astro
@@ -48,7 +48,7 @@ const entries = await contentfulClient.getEntries<Project>({})
               subheading={entry?.fields?.description}
               imagePath={entry?.fields?.img?.fields?.file.url}
               altText={entry?.fields?.img?.fields.title}
-              class="sm:w-2/f w-full"
+              class="w-full sm:w-2/f"
             />
           ))
         }

--- a/src/pages/pt/portfolio.astro
+++ b/src/pages/pt/portfolio.astro
@@ -1,0 +1,58 @@
+---
+import { useTranslations } from '../../i18n'
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import TopLayout from '../../layouts/TopLayout.astro'
+import BottomLayout from '../../layouts/BottomLayout.astro'
+import ProjectCard from '../../components/ProjectCard.astro'
+
+import { contentfulClient } from '../../lib/contentful'
+import { documentToHtmlString } from '@contentful/rich-text-html-renderer'
+import type { EntryFieldTypes } from 'contentful'
+
+const { currentLocale } = Astro
+const t = useTranslations(currentLocale as string)
+
+interface Project {
+  contentTypeId: 'Projects'
+  fields: {
+    name: EntryFieldTypes.Text
+    img: EntryFieldTypes.AssetLink
+    website: EntryFieldTypes.EntryResourceLink<any>
+    repositorio: EntryFieldTypes.EntryResourceLink<any>
+  }
+}
+
+const entries = await contentfulClient.getEntries<Project>({})
+---
+
+<BaseLayout
+  title={t('portfolio.title')}
+  description={t('portfolio.description')}
+>
+  <main class="flex min-h-[80vh] flex-auto flex-col" transition:animate="slide">
+    <TopLayout>
+      <h2
+        class="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0"
+      >
+        {t('portfolio.heading')}
+      </h2>
+    </TopLayout>
+    <BottomLayout size="xl">
+      <div class="flex w-full flex-wrap justify-center gap-2">
+        {
+          entries.items.map((entry: any) => (
+            <ProjectCard
+              key={entry?.sys?.id}
+              href={entry?.fields?.website}
+              heading={entry?.fields?.name}
+              subheading={entry?.fields?.description}
+              imagePath={entry?.fields?.img?.fields?.file.url}
+              altText={entry?.fields?.img?.fields.title}
+              class="w-full sm:w-2/f"
+            />
+          ))
+        }
+      </div>
+    </BottomLayout>
+  </main>
+</BaseLayout>

--- a/src/pages/pt/work.astro
+++ b/src/pages/pt/work.astro
@@ -1,0 +1,47 @@
+---
+import { useTranslations } from '../../i18n'
+import BaseLayout from '../../layouts/BaseLayout.astro'
+import TopLayout from '../../layouts/TopLayout.astro'
+import BottomLayout from '../../layouts/BottomLayout.astro'
+import { EXPERIENCE } from '../../lib/constants'
+
+const { currentLocale } = Astro
+const t = useTranslations(currentLocale as string)
+---
+
+<BaseLayout title={t('nav.work')} description={t('nav.work')}>
+  <main class="flex min-h-[80vh] flex-auto flex-col" transition:animate="fade">
+    <TopLayout>
+      <h2
+        class="scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight first:mt-0"
+      >
+        {t('nav.work')}
+      </h2>
+    </TopLayout>
+    <BottomLayout>
+      <ul>
+        {
+          EXPERIENCE.map((entry) => (
+            <li class="animate mt-4 border-b border-black/10 py-8 first-of-type:mt-0 first-of-type:pt-0 last-of-type:border-none dark:border-white/25">
+              <div class="mb-4 text-sm uppercase">
+                {entry.start} - {entry.end}
+              </div>
+              <a
+                href={entry.link ?? ''}
+                class={`font-semibold ${entry?.link ? 'text-primary' : 'text-foreground'}`}
+              >
+                {t(entry.company)}
+              </a>
+              <div class="text-sm font-semibold">{t(entry.position)}</div>
+              <article class="prose dark:prose-invert">
+                {entry.tasks.map((i) => (
+                  <p>{t(i)}</p>
+                ))}
+              </article>
+            </li>
+          ))
+        }
+      </ul>
+    </BottomLayout>
+  </main>
+</BaseLayout>


### PR DESCRIPTION
- Implemented internationalization for English, Spanish, and Portuguese.
- Updated work history to include a new job at Mercado Libre and an end date for Spot2.
- Improved job descriptions.
- Refactored the entire site to use the new i18n system.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add full i18n support (en/es/pt) with localized pages and components, locale-aware navigation with a language switcher, updated work history (incl. Mercado Libre), and a redirect to the default locale.
> 
> - **i18n (multilingual: `en`, `es`, `pt`)**:
>   - Add Astro `i18n` config with `defaultLocale: 'en'`; introduce `src/i18n.ts` and locale files `src/locales/{en,es,pt}.json`.
>   - Localize pages with new routes: `pages/{en,es,pt}/{index,work,portfolio,404}.astro`; root `pages/index.astro` now redirects to default locale.
>   - Refactor UI to use translations and locale-aware URLs: update `Header.astro` (locale links, `LanguageSwitcher`), and sections (`IntroCard`, `AboutMe`, `CVCard`, `ContactsCard`, `Now`, `StudyCard`, `TattooCard`).
>   - Add `LanguageSwitcher.astro` using `flag-icons` and `getRelativeLocaleUrl`.
> - **Work history**:
>   - Replace literals in `EXPERIENCE` with translation keys; add Mercado Libre role and set end dates/entries for prior roles.
> - **Deps**:
>   - Add `flag-icons` dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 473d93bfad53a1877b4fc3dfa12e8cde646f174e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->